### PR TITLE
Fix ChemmineOB library installation

### DIFF
--- a/.Renviron
+++ b/.Renviron
@@ -1,0 +1,2 @@
+OPEN_BABEL_LIBDIR="/srv/conda/envs/notebook/lib/openbabel/3.1.0"
+OPEN_BABEL_INCDIR="/srv/conda/envs/notebook/include/openbabel3"

--- a/apt.txt
+++ b/apt.txt
@@ -1,0 +1,1 @@
+libeigen3-dev

--- a/environment.yml
+++ b/environment.yml
@@ -6,3 +6,4 @@ dependencies:
   - r-base=4.0.5
   - bioconductor-keggrest
   - bioconductor-chemminer
+  - r-biocmanager

--- a/postBuild
+++ b/postBuild
@@ -2,5 +2,4 @@
 
 set -ex
 
-LD_LIBRARY_PATH=${NB_PYTHON_PREFIX}/lib:${NB_PYTHON_PREFIX}/include:${NB_PYTHON_PREFIX}/include/openbabel3:${LD_LIBRARY_PATH}
 R -e 'BiocManager::install(ask = F)' && R -e 'BiocManager::install("ChemmineOB")'

--- a/postBuild
+++ b/postBuild
@@ -2,4 +2,5 @@
 
 set -ex
 
+export LD_LIBRARY_PATH=${NB_PYTHON_PREFIX}/lib:${NB_PYTHON_PREFIX}/include:${NB_PYTHON_PREFIX}/include/openbabel3:${LD_LIBRARY_PATH}
 R -e 'BiocManager::install(ask = F)' && R -e 'BiocManager::install("ChemmineOB")'

--- a/postBuild
+++ b/postBuild
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -ex
+
+R -e 'BiocManager::install(ask = F)' && R -e 'BiocManager::install("ChemmineOB")'

--- a/postBuild
+++ b/postBuild
@@ -2,5 +2,5 @@
 
 set -ex
 
-export LD_LIBRARY_PATH=${NB_PYTHON_PREFIX}/lib:${NB_PYTHON_PREFIX}/include:${NB_PYTHON_PREFIX}/include/openbabel3:${LD_LIBRARY_PATH}
+LD_LIBRARY_PATH=${NB_PYTHON_PREFIX}/lib:${NB_PYTHON_PREFIX}/include:${NB_PYTHON_PREFIX}/include/openbabel3:${LD_LIBRARY_PATH}
 R -e 'BiocManager::install(ask = F)' && R -e 'BiocManager::install("ChemmineOB")'

--- a/start
+++ b/start
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+export LD_LIBRARY_PATH=${NB_PYTHON_PREFIX}/lib:${NB_PYTHON_PREFIX}/include:${NB_PYTHON_PREFIX}/include/openbabel3:${LD_LIBRARY_PATH}
+exec "$@"

--- a/start
+++ b/start
@@ -1,6 +1,0 @@
-#!/bin/bash
-set -e
-LD_LIBRARY_PATH=${NB_PYTHON_PREFIX}/lib:${NB_PYTHON_PREFIX}/include:${NB_PYTHON_PREFIX}/include/openbabel3:${LD_LIBRARY_PATH}
-export OPEN_BABEL_LIBDIR="${NB_PYTHON_PREFIX}/lib/openbabel/3.1.0"
-export OPEN_BABEL_INCDIR="${NB_PYTHON_PREFIX}/include/openbabel3"
-exec "$@"


### PR DESCRIPTION
Installing ChemmineOB fails because of missing dependencies (openbabel, and Eigen/Core).

## Fix

1. Install the `libeigen3-dev` Ubuntu package by putting it in `apt.txt`
2. Set two environment variables `OPEN_BABEL_LIBDIR` and `OPEN_BABEL_INCDIR` in the `.Renviron` file

## Quality-of-life improvements 

To avoid extra steps when starting up the RStudio environment:

1. Install `r-biocmanager` using `environment.yml`
2. Use `BiocManager` to install `ChemmineOB` using the `postBuild` script

## Tidy-up

Removed `start` script which is now superfluous.

## Running

### Option A: Try on mybinder.org

<https://mybinder.org/v2/gh/julianpistorius/binder_volcalc/fix-package-install-issues?urlpath=%2Frstudio>

### Option B: Use `repo2docker`

```bash
python3 -m pip install jupyter-repo2docker
repo2docker --ref fix-package-install-issues https://github.com/julianpistorius/binder_volcalc.git
```

Other ways to install `repo2docker`: https://repo2docker.readthedocs.io/en/latest/install.html

## Checking correctness

Run the following in the R console:

```r
library(ChemmineOB)
```

It should _NOT_ show an error.